### PR TITLE
Updated the favicon and nested list styling

### DIFF
--- a/clubs/blank-template/index.html
+++ b/clubs/blank-template/index.html
@@ -5,8 +5,9 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href='https://fonts.googleapis.com/css?family=Fira+Sans:400,400italic,500,500italic,700' rel='stylesheet' type='text/css'>
-    <link rel="icon" type="image/ico" href="https://mozillascience.org/img/favicon.ico">
+    <link rel="icon" type="image/ico" href="https://teach.mozilla.org/img/favicon.ico">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
+
     <!-- <link rel="stylesheet/less" href="../template-assets/css/style.less"> -->
     <link rel="stylesheet" href="../template-assets/css/style.css">
 

--- a/clubs/events-women-girls-guide/index.html
+++ b/clubs/events-women-girls-guide/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href='https://fonts.googleapis.com/css?family=Fira+Sans:400,400italic,500,500italic,700' rel='stylesheet' type='text/css'>
-    <link rel="icon" type="image/ico" href="https://mozillascience.org/img/favicon.ico">
+    <link rel="icon" type="image/ico" href="https://teach.mozilla.org/img/favicon.ico">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
     <!-- <link rel="stylesheet/less" href="../template-assets/css/style.less"> -->
     <link rel="stylesheet" href="../template-assets/css/style.css">

--- a/clubs/markdown-guide/content.md
+++ b/clubs/markdown-guide/content.md
@@ -71,22 +71,30 @@ You can ever ~~cross things out~~.
 
 * This is a bullet in an un-ordered list
 * This is a bullet in an un-ordered list
+  * This is a sub-bullet
+  * This is a sub-bullet
 * This is a bullet in an un-ordered list
 
 ```
 * This is a bullet in an un-ordered list
 * This is a bullet in an un-ordered list
+  * This is a sub-bullet
+  * This is a sub-bullet
 * This is a bullet in an un-ordered list
 ```
 
 1. This is a bullet in an ordered list
 2. This is a bullet in an un-ordered list
+  1. This is a sub-bullet
+  2. This is also a sub bullet
 3. This is a bullet in an un-ordered list
 
 
 ```
 1. The fist item
 2. The second item
+  1. This is a sub-bullet
+  2. This is also a sub bullet
 3. The third item
 ```
 

--- a/clubs/markdown-guide/index.html
+++ b/clubs/markdown-guide/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href='https://fonts.googleapis.com/css?family=Fira+Sans:400,400italic,500,500italic,700' rel='stylesheet' type='text/css'>
-    <link rel="icon" type="image/ico" href="https://mozillascience.org/img/favicon.ico">
+    <link rel="icon" type="image/ico" href="https://teach.mozilla.org/img/favicon.ico">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
     <link rel="stylesheet/less" href="../template-assets/css/style.less">
 

--- a/clubs/mixing-afterschool-program/index.html
+++ b/clubs/mixing-afterschool-program/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href='https://fonts.googleapis.com/css?family=Fira+Sans:400,400italic,500,500italic,700' rel='stylesheet' type='text/css'>
-    <link rel="icon" type="image/ico" href="https://mozillascience.org/img/favicon.ico">
+    <link rel="icon" type="image/ico" href="https://teach.mozilla.org/img/favicon.ico">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
     <!-- <link rel="stylesheet/less" href="../template-assets/css/style.less"> -->
     <link rel="stylesheet" href="../template-assets/css/style.css">

--- a/clubs/template-assets/css/style.css
+++ b/clubs/template-assets/css/style.css
@@ -113,18 +113,10 @@ article > ul li,
 article ol li {
   margin-bottom: 8px;
 }
-article ul li {
-  list-style-type: none;
-  position: relative;
-}
-article ul li:before {
-  content: ".";
-  position: absolute;
-  left: -15px;
-  font-weight: 700;
-  color: inherit;
-  font-size: 25px;
-  top: -6px;
+article li ul,
+article li ol {
+  padding-left: 20px;
+  margin: 12px 0;
 }
 .logo {
   position: relative;

--- a/clubs/template-assets/css/style.less
+++ b/clubs/template-assets/css/style.less
@@ -139,7 +139,6 @@ article {
   margin-right: 55px;
   z-index: 1;
 
-
   img {
     max-width: 100%;
   }
@@ -159,20 +158,10 @@ article {
     }
   }
 
-  ul {
-    li {
-      list-style-type: none;
-      position: relative;
-
-      &:before {
-        content: ".";
-        position: absolute;
-        left: -15px;
-        font-weight: 700;
-        color: inherit;
-        font-size: 25px;
-        top: -6px;
-      }
+  li {
+    ul, ol {
+      padding-left: 20px;
+      margin: 12px 0;
     }
   }
 }

--- a/clubs/train-the-trainer-guide/index.html
+++ b/clubs/train-the-trainer-guide/index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href='https://fonts.googleapis.com/css?family=Fira+Sans:400,400italic,500,500italic,700' rel='stylesheet' type='text/css'>
-    <link rel="icon" type="image/ico" href="https://mozillascience.org/img/favicon.ico">
+    <link rel="icon" type="image/ico" href="https://teach.mozilla.org/img/favicon.ico">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
     <!-- <link rel="stylesheet/less" href="../template-assets/css/style.less"> -->
     <link rel="stylesheet" href="../template-assets/css/style.css">


### PR DESCRIPTION
- Changed the favicon to the mozilla "m" instead of the Mozilla Science logo in the template and the published guides
- Fixed list styling so that nested lists are properly indented now
- Updated the markdown guide with examples of nested lists

Fixes #352 
